### PR TITLE
README: fix `mermaid_initialize_options` usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ antora:
     - require: '@sntke/antora-mermaid-extension' # <1>
       mermaid_library_url: https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs # <2>
       script_stem: header-scripts # <3>
-      mermaid_initialize_options: "{ startOnLoad: true }" #<4>
+      mermaid_initialize_options: # <4>
+        start_on_load: true
 
 ```
 
@@ -68,6 +69,8 @@ antora:
 * <2> URL of Mermaid.js library (optional)
 * <3> Stem that exists in the handlebar templates of UI bundle where HTML script element for `mermaid.js` is placed. (optional)
 * <4> The argument to mermaid.initialize(). (optional)
+      Make sure to convert the Mermaid config keys to snake case, e.g., `startOnLoad` -> `start_on_load` or `themeVariables` -> `theme_variables`.
+      Refer to [the Antora docs](https://docs.antora.org/antora/latest/extend/configure-extension/#configuration-key-transformation) for details.
 
 ## Migration to 0.0.4
 


### PR DESCRIPTION
It's rather unexpected but Antora assumes that the configuration uses
snake case only and converts the options to camel case internally. Quote
from the docs [1]:

> In YAML, key names use the snake_case naming convention. In
> JavaScript, property names use the camelCase naming convention. To help
> bridge the naming convention mismatch between YAML and JavaScript,
> Antora automatically transforms snake_case key names in the playbook
> file into camelCase properties on the configuration object. For example,
> Antora transforms cache_dir to cacheDir. Most of the time, this isn’t a
> problem. However, if your extension passes configuration or data on to
> another application, this transformation can be problematic.

Well, it's a problem here and this commit makes sure this peculiarity is
mentioned in the README.

[1] https://docs.antora.org/antora/latest/extend/configure-extension
