### PR TITLE
refs #11: fixed: The extension does not work when asciidoc.attributes…

### DIFF
--- a/lib/extension.js
+++ b/lib/extension.js
@@ -4,7 +4,7 @@
 
 module.exports.register = (context, {config}) => {
     context.on('uiLoaded', appendMermaidScript(config))
-    context.on('contentClassified', appendBlockProcessor)
+    context.on('beforeProcess', appendBlockProcessor)
 }
 
 const DEFAULT_MERMAID_LIBRARY_URL = 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs'


### PR DESCRIPTION
… is used.

According to https://docs.antora.org/antora/latest/extend/generator-events-reference/ ,

> If the variable is locked, meaning it cannot be replaced, it’s italicized.

and `beforeProcess`, unlike `contentClassified` , has non-italicized `siteAsciiDocConfig` in the table. 