### PR TITLE
Refs #19: Introduced `mermaid_initialize_options_raw_text_override`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Antora Mermaid Extension
 
-**NOTE: Migration to 0.0.4 and newer might require you to update to `antora-playbook.yaml`. See [Migration to 0.0.4](#migration-to-004).**
+**NOTE: Migration to 0.0.4 and newer might require you to update to `antora-playbook.yaml`. See [Migration to 0.0.4](#migration-to-004-and-newer).**
 
 This extension visualizes [Listing Blocks](https://docs.asciidoctor.org/asciidoc/latest/verbatim/listing-blocks/)
 and [Literal Blocks](https://docs.asciidoctor.org/asciidoc/latest/verbatim/literal-blocks/)
@@ -71,6 +71,19 @@ antora:
 * <4> The argument to mermaid.initialize(). (optional)
       Make sure to convert the Mermaid config keys to snake case, e.g., `startOnLoad` -> `start_on_load` or `themeVariables` -> `theme_variables`.
       Refer to [the Antora docs](https://docs.antora.org/antora/latest/extend/configure-extension/#configuration-key-transformation) for details.
+
+If you have a special need to specify the argument to `mermaid.initialize(argument)`, use `mermaid_initialize_options_raw_text_override` instead of `mermaid_initialize_options`.
+Its value is placed between `mermaid.initialize(` and `)` as-is. So you would set `antora-playbook.yaml` like this:
+
+```yaml
+antora:
+  extensions:
+    - require: '@sntke/antora-mermaid-extension'
+      script_stem: header-scripts
+      mermaid_initialize_options_raw_text_override: '{"startOnLoad":true, "theme":"dark", "postRenderCallback": mermaidPostRender }'
+```
+
+Note: You must quote the entire JSON string with single quotes to avoid being parsed as JSON in YAML.
 
 ## Migration to 0.0.4 and newer
 

--- a/lib/extension.js
+++ b/lib/extension.js
@@ -3,7 +3,8 @@
 // based on https://gitlab.com/djencks/antora-generic-svg/-/blob/master/lib/extension.js
 
 module.exports.register = (context, {config}) => {
-    context.on('uiLoaded', appendMermaidScript(config))
+    const logger = this.getLogger('antora-mermaid-extension')
+    context.on('uiLoaded', appendMermaidScript(config,logger))
     context.on('beforeProcess', appendBlockProcessor)
 }
 
@@ -24,7 +25,7 @@ const appendBlockProcessor = ({siteAsciiDocConfig}) => {
     })
 };
 
-const appendMermaidScript = (config) => ({uiCatalog}) => {
+const appendMermaidScript = (config,logger) => ({uiCatalog}) => {
 
     // noinspection JSUnresolvedVariable
     const mermaidLibraryUrl = config.mermaidLibraryUrl || DEFAULT_MERMAID_LIBRARY_URL
@@ -33,10 +34,16 @@ const appendMermaidScript = (config) => ({uiCatalog}) => {
     // noinspection JSUnresolvedVariable
     const mermaidInitializeOptions = JSON.stringify(config.mermaidInitializeOptions || DEFAULT_MERMAID_INITIALIZE_OPTIONS)
 
+    const mermaidInitializeOptionsRawTextOverride = config.mermaidInitializeOptionsRawTextOverride
+    if (mermaidInitializeOptionsRawTextOverride && config.mermaidInitializeOptions) {
+        logger.warn('Both mermaidInitializeOptions and mermaidInitializeOptionsRawTextOverride are set. mermaidInitializeOptionsRawTextOverride is used.')
+    }
+
     // noinspection JSUnresolvedFunction
     if (uiCatalog.findByType('partial').some(({path}) => path === SCRIPT_PARTIAL_PATH)) return
 
-    const hbsContent = `<script type="module">import mermaid from '${mermaidLibraryUrl}'; mermaid.initialize(${mermaidInitializeOptions});</script>`
+    const mio = mermaidInitializeOptionsRawTextOverride || mermaidInitializeOptions;
+    const hbsContent = `<script type="module">import mermaid from '${mermaidLibraryUrl}'; mermaid.initialize(${mio});</script>`
     // noinspection JSUnresolvedFunction
     uiCatalog.addFile({
         contents: Buffer.from(hbsContent),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sntke/antora-mermaid-extension",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sntke/antora-mermaid-extension",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "license": "MIT",
       "devDependencies": {
         "asciidoctor": "^3.0.4",
@@ -67,7 +67,6 @@
       "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-3.0.4.tgz",
       "integrity": "sha512-41SDMi7iRRBViPe0L6VWFTe55bv6HEOJeRqMj5+E5wB1YPdUPuTucL4UAESPZM6OWmn4t/5qM5LusXomFUVwVQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@asciidoctor/opal-runtime": "3.0.1",
         "unxhr": "1.2.0"
@@ -91,9 +90,9 @@
       }
     },
     "node_modules/@asciidoctor/opal-runtime/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -121,10 +120,11 @@
       }
     },
     "node_modules/@asciidoctor/opal-runtime/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -283,9 +283,9 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -617,9 +617,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -627,10 +627,11 @@
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -694,10 +695,11 @@
       }
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.2",
@@ -939,10 +941,11 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1349,9 +1352,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.20.0.tgz",
-      "integrity": "sha512-MJZrkjyd7DeC+uPZh+5/YaMDxFiiEEaDgbUSVMXayofAkDWF1088CDo+2RPg7B1BuS1qf1vgNE7xqwPxE0DuSQ==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sntke/antora-mermaid-extension",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Mermaid extension for Antora",
   "main": "lib/extension.js",
   "repository": {

--- a/test/extension.test.mjs
+++ b/test/extension.test.mjs
@@ -3,10 +3,10 @@ import { ok, strictEqual } from "node:assert"
 
 import asciidoctor from 'asciidoctor'
 import { load } from 'cheerio'
+import extension from '../lib/extension.js'
 import { processMermaidBlock as _processMermaidBlock } from '../lib/extension.js'
 
 const Asciidoctor = asciidoctor()
-
 
 describe('The extension produce inline SVG from the mermaid block', () => {
     const registry = Asciidoctor.Extensions.create()
@@ -53,3 +53,92 @@ stateDiagram-v2
         strictEqual(html('#example-diagram div[class=title]').text(), 'Fig 1. Test caption #1')
     })
 });
+
+describe('mermaidInitializeOptionsRawTextOverride behavior', () => {
+    const createUiCatalog = () => {
+        const addedFiles = []
+        return {
+            addedFiles,
+            findByType: () => [],
+            addFile: (file) => {
+                addedFiles.push(file)
+            },
+        }
+    }
+
+    const executeUiLoaded = (config) => {
+        const events = {}
+        const warns = []
+        const context = {
+            on: (eventName, handler) => {
+                events[eventName] = handler
+            }
+        }
+        const originalGetLogger = extension.getLogger
+        extension.getLogger = () => ({
+            warn: (message) => warns.push(message)
+        })
+
+        extension.register(context, { config })
+
+        if (originalGetLogger) {
+            extension.getLogger = originalGetLogger
+        } else {
+            delete extension.getLogger
+        }
+
+        const uiCatalog = createUiCatalog()
+        events.uiLoaded({ uiCatalog })
+
+        return { uiCatalog, warns }
+    }
+
+    it('uses raw text override as initialize argument', () => {
+        const raw = '{ startOnLoad: false, securityLevel: "strict" }'
+        const { uiCatalog } = executeUiLoaded({
+            mermaidInitializeOptionsRawTextOverride: raw,
+        })
+
+        strictEqual(uiCatalog.addedFiles.length, 1)
+        const script = uiCatalog.addedFiles[0].contents.toString('utf8')
+        ok(script.includes(`mermaid.initialize(${raw});`))
+    })
+
+    it('prefers raw text override over mermaidInitializeOptions and warns once', () => {
+        const raw = '{ startOnLoad: false }'
+        const { uiCatalog, warns } = executeUiLoaded({
+            mermaidInitializeOptionsRawTextOverride: raw,
+            mermaidInitializeOptions: { startOnLoad: true }
+        })
+
+        strictEqual(warns.length, 1)
+        strictEqual(
+            warns[0],
+            'Both mermaidInitializeOptions and mermaidInitializeOptionsRawTextOverride are set. mermaidInitializeOptionsRawTextOverride is used.'
+        )
+
+        const script = uiCatalog.addedFiles[0].contents.toString('utf8')
+        ok(script.includes(`mermaid.initialize(${raw});`))
+        ok(!script.includes('mermaid.initialize({"startOnLoad":true});'))
+    })
+
+    it('does not warn when only raw text override is set', () => {
+        const { warns } = executeUiLoaded({
+            mermaidInitializeOptionsRawTextOverride: '{ startOnLoad: false }',
+        })
+
+        strictEqual(warns.length, 0)
+    })
+
+    it('uses mermaidInitializeOptions when raw text override is not set', () => {
+        const { uiCatalog, warns } = executeUiLoaded({
+            mermaidInitializeOptions: { startOnLoad: false, securityLevel: 'strict' },
+        })
+
+        strictEqual(warns.length, 0)
+        strictEqual(uiCatalog.addedFiles.length, 1)
+
+        const script = uiCatalog.addedFiles[0].contents.toString('utf8')
+        ok(script.includes('mermaid.initialize({"startOnLoad":false,"securityLevel":"strict"});'))
+    })
+})


### PR DESCRIPTION
YAML does not have a data type to represent function reference (and even if it does, the reference must be valid at the time of parsing).

So passing raw text as the argument to `mermaid.initialize()` is needed.